### PR TITLE
fix: hide 3 services and removed 2025 from blogs

### DIFF
--- a/newapp/src/components/Header.astro
+++ b/newapp/src/components/Header.astro
@@ -7,7 +7,7 @@ import Dropdown from "$lib/components/common/Dropdown.svelte";
 import ToggleTheme from "$lib/components/common/ToggleTheme.svelte"
 import { getCollection } from "astro:content";
 
-const services = Object.values(await getCollection('services')).sort((a, b) => a.data.order - b.data.order);
+const services = (Object.values(await getCollection('services')).sort((a, b) => a.data.order - b.data.order)).filter(service => service.id !== "technology-consulting" && service.id !== "product-modernization" &&  service.id !== "cloud-infrastructure-services")
 
 import Sidebar from "./Sidebar.astro";
 const currentUrl = Astro.url.pathname.split("/")

--- a/newapp/src/content/blog/the-role-of-platform-engineering-in-multi-cloud-strategies.md
+++ b/newapp/src/content/blog/the-role-of-platform-engineering-in-multi-cloud-strategies.md
@@ -1,8 +1,8 @@
 ---
-title: "The Role of Platform Engineering in Multi-Cloud Strategies for 2025"
-slug: "multi-cloud-strategies-for-2025"
+title: "The Role of Platform Engineering in Multi-Cloud Strategies"
+slug: "multi-cloud-strategies"
 description: "As enterprises increasingly adopt multi-cloud strategies to optimize their IT infrastructure, the role of platform engineering becomes crucial. This approach involves using multiple cloud service providers to fulfill various IT needs, and platform engineering is essential for managing and integrating these diverse cloud environments."
-seoTitle: "Multi-Cloud Strategies for 2025 | Platform Engineering Insights | Improwised Tech"
+seoTitle: "Multi-Cloud Strategies | Platform Engineering Insights | Improwised Tech"
 seoDescription: "As enterprises increasingly adopt multi-cloud strategies to optimize their IT infrastructure, the role of platform engineering becomes crucial."
 tags: [Optimization, Cost Optimization]
 publishDate: 2024-12-27

--- a/newapp/src/content/blog/top-10-platform-engineering-companies.md
+++ b/newapp/src/content/blog/top-10-platform-engineering-companies.md
@@ -1,17 +1,17 @@
 ---
-title: "Top 10 Platform Engineering Companies in 2025"
+title: "Top 10 Platform Engineering Companies"
 slug: 'top-10-platform-engineering-companies'
-description: 'Discover the top platform engineering companies in 2025—leaders helping teams ship software faster, scale reliably, and optimize cloud infrastructure with modern developer platforms'
-seoTitle: 'Best Platform Engineering Companies for Startups 2025'
-seoDescription: 'Looking to scale smart? Discover the top 10 platform engineering companies startups trust in 2025 for automation, DevOps, and infrastructure success'
+description: 'Discover the top platform engineering companies helping teams ship software faster, scale reliably, and optimize cloud infrastructure with modern developer platforms'
+seoTitle: 'Best Platform Engineering Companies for Startups'
+seoDescription: 'Looking to scale smart? Discover the top 10 platform engineering companies startups trust for automation, DevOps, and infrastructure success'
 tags: [Platform Engineering]
 publishDate: 2025-07-03
 author: 'Priyank Dhami'
 image: '$lib/images/blogs/top-10-platform-engineering-blog-image-head.png'
 linkTags:
-  - title: "Top 10 Platform Engineering Companies in 2025"
+  - title: "Top 10 Platform Engineering Companies"
   - title: "What is Platform Engineering?"
-  - title: "Why It Matters in 2025"
+  - title: "Why It Matters"
   - title: "What Makes a Great Platform Engineering Partner?"
     children: 
       - "1. Improwised Technologies"
@@ -27,13 +27,13 @@ linkTags:
   - title: "Final Thoughts"
 ---
 
-## Top 10 Platform Engineering Companies in 2025
+## Top 10 Platform Engineering Companies
 
 Platform engineering is no longer optional. In 2025, it's essential for fast-growing businesses. As teams scale, managing infrastructure manually becomes a bottleneck. Platform engineering removes that friction. They need internal platforms that empower developers, automate operations, and deliver faster value.  
 
 We've rounded up 10 companies that are doing just that. Whether you're a CTO, DevOps leader, or startup founder, this list will help you find the right partner to build your future.
 
-![Top 10 Platform Engineering Companies in 2025]($lib/images/blogs/top-10-platform-engineering-blog-image-body.png)
+![Top 10 Platform Engineering Companies]($lib/images/blogs/top-10-platform-engineering-blog-image-body.png)
 
 ## What is Platform Engineering?
 
@@ -41,7 +41,7 @@ Platform engineering builds internal tools that simplify development and streaml
 
 Imagine a vending machine for infrastructure—where developers pick what they need and get it instantly, securely, and consistently. That’s the power of an Internal Developer Platform (IDP).
 
-## Why It Matters in 2025
+## Why It Matters
 
 - **Faster development:** Less waiting on infra, more shipping code.
 
@@ -71,7 +71,7 @@ Look for companies that offer:
 
 - Scalable, modular solutions  
 
-Let’s meet the teams raising the bar in 2025.
+Let’s meet the teams raising the bar.
 
 ### 1. <a href="https://www.improwised.com/" target="_blank">Improwised Technologies</a>
 

--- a/newapp/src/content/blog/top-golang-development-companies.md
+++ b/newapp/src/content/blog/top-golang-development-companies.md
@@ -1,6 +1,6 @@
 ---
-title: "The Top 10 Golang Development Companies Powering Modern Innovation in 2025"
-slug: "top-golang-development-companies-2025"
+title: "The Top 10 Golang Development Companies Powering Modern Innovation"
+slug: "top-golang-development-companies"
 description: "Choosing the right Go partner? We rank the best Golang development companies shaping the tech landscape this year."
 seoTitle: "Top Golang Development Companies 2025 | Improwised"
 seoDescription: "Looking for reliable Golang developers? Improwised highlights 2025’s best Go development partners building future-ready, high-performance systems."
@@ -28,11 +28,6 @@ blockCategory: "monitoring-and-observability"
 
 Golang, commonly known as Go, has rapidly ascended as a preferred programming language for developing highly efficient, scalable, and reliable software systems. Designed by Google, Go offers a compelling combination of simplicity, performance, and robust concurrency features. Its lightweight goroutines and channels are particularly well-suited for building high-performance backend services, cloud-native applications, and complex network programming solutions. The language's static typing and built-in garbage collection contribute to fewer runtime errors and streamlined maintenance, making it an optimal choice for critical backend development where stability and speed are paramount.
 
-While Golang inherently offers significant technical advantages, realizing its full potential within a business context necessitates partnering with a development firm that possesses profound expertise and a proven track record. The right partner brings not only coding proficiency but also a strategic understanding of how Go can be leveraged to align with specific business objectives, ensuring architectural soundness, long-term scalability, and maintainability.
-
-This comprehensive guide explores the leading Golang development companies that are at the forefront of shaping the future of software. Extensive research has been conducted to identify firms that demonstrate exceptional technical prowess, high client satisfaction, and innovative solution delivery. The objective is to provide a valuable resource for businesses seeking to harness Golang for their next major project, with a particular emphasis on Improwised Technologies , a company recognized for its leadership in Golang innovation.
-
-The increasing number of top-tier development companies explicitly highlighting Golang as a core or significant focus area indicates that Go is no longer merely a niche language but a strategic investment for organizations prioritizing high performance and scalability. This widespread adoption by leading firms points to a maturing market for Go expertise, where businesses are making deliberate decisions to invest in the language for specific, high-value use cases. This positions Golang as a fundamental asset for future-proofing applications and infrastructure.
 
 ![Blog Image]($lib/images/blogs/top-10-golang-development-companies-body.png)
 


### PR DESCRIPTION
- removed 3 services i.e. product-modernization, technology-consulting and cloud infrastructure services from navbar
- removed year/dates from the blogs url and heading 